### PR TITLE
Eliminate `methodNames`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Attribute changes will be batched via [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/Window/queueMicrotask), by [@compulim](https://github.com/compulim), in PR [#8](https://github.com/compulim/react-define-as-custom-element/pull/8)
-- Support custom methods by registering via `useMethodCallback()`, by [@compulim](https://github.com/compulim), in PR [#9](https://github.com/compulim/react-define-as-custom-element/pull/9)
+- Support custom methods by registering via `useMethodCallback()`, by [@compulim](https://github.com/compulim), in PR [#9](https://github.com/compulim/react-define-as-custom-element/pull/9) and [#10](https://github.com/compulim/react-define-as-custom-element/pull/10)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ const MyInput = ({ value }: { value?: string | undefined }) => {
 
 ### Defining custom methods
 
-Custom methods can be added to the custom element. When the method is called, it will trigger the callback function registered with the `useMethodCallback()` hook.
+Custom methods can be added to the custom element via the `useMethodCallback()` hook.
 
 ```tsx
 import { defineAsCustomElement, useMethodCallback } from 'react-define-as-custom-element';
@@ -149,7 +149,7 @@ const MyCalculator = () => {
   const [right, setRight] = useState<number>(0);
   const [sum, setSum] = useState<number>(left + right);
 
-  useMethodCallback<(left: number, right: number) => number>('sum', (left, right) => {
+  useMethodCallback('sum', (left: number, right: number): number => {
     setLeft(left);
     setRight(right);
     setSum(left + right);
@@ -164,16 +164,16 @@ const MyCalculator = () => {
   );
 };
 
-defineAsCustomElement('my-calculator', {}, { methodNames: ['sum'] });
+defineAsCustomElement('my-calculator', MyCalculator, {});
 ```
 
-After defining the custom element, a new `sum()` function will be added to the custom element.
+After calling the `useMethodCallback('sum')` hook, a `sum()` function will be added to the custom element.
 
 ```tsx
 document.getElementsByTagName('my-calculator')[0].sum(1, 2); // Returns 3.
 ```
 
-For every instance of the component, it should only call `useMethodCallback()` hook once for every registered method. If more than one callback function is registered, the behavior will be indeterministic.
+`useMethodCallback()` hook should only called once for every method. If more than one method is registered with the same name, its behavior will be indeterministic.
 
 ## Behaviors
 

--- a/packages/integration-test/test/webDriver/use-method-callback-with-portal/index.tsx
+++ b/packages/integration-test/test/webDriver/use-method-callback-with-portal/index.tsx
@@ -26,12 +26,7 @@ const MyLabel = () => {
   );
 };
 
-const { Portal } = defineAsCustomElementWithPortal(
-  MyLabel,
-  'use-method-callback--my-label',
-  {},
-  { methodNames: ['setLabel', 'setValue'] }
-);
+const { Portal } = defineAsCustomElementWithPortal(MyLabel, 'use-method-callback--my-label', {});
 
 window.__run__ = () => {
   const mainElement = document.querySelector('main') || undefined;

--- a/packages/integration-test/test/webDriver/use-method-callback/index.tsx
+++ b/packages/integration-test/test/webDriver/use-method-callback/index.tsx
@@ -25,4 +25,4 @@ const MyLabel = () => {
   );
 };
 
-defineAsCustomElement(MyLabel, 'use-method-callback--my-label', {}, { methodNames: ['setLabel', 'setValue'] });
+defineAsCustomElement(MyLabel, 'use-method-callback--my-label', {});

--- a/packages/react-define-as-custom-element/src/defineAsCustomElement.tsx
+++ b/packages/react-define-as-custom-element/src/defineAsCustomElement.tsx
@@ -25,7 +25,6 @@ export default function defineAsCustomElement<T extends string>(
       constructor() {
         super(
           attributesMap,
-          init?.methodNames,
           init?.shadowRoot,
           (props, element, setMethodCallback) =>
             render(

--- a/packages/react-define-as-custom-element/src/defineAsCustomElementWithPortal.tsx
+++ b/packages/react-define-as-custom-element/src/defineAsCustomElementWithPortal.tsx
@@ -8,7 +8,7 @@ import { type AttributeAsProps, type AttributesMap, type DefineAsCustomElementIn
 
 type InstanceMapEntry<T extends object> = Readonly<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [HTMLElement | ShadowRoot, Readonly<T>, (fn: (name: string, ...args: any[]) => any) => void]
+  [HTMLElement | ShadowRoot, Readonly<T>, (name: string, fn: ((...args: any[]) => any) | undefined) => void]
 >;
 type InstanceMap<T extends string> = ReadonlyMap<string, InstanceMapEntry<AttributeAsProps<T>>>;
 
@@ -31,7 +31,6 @@ export default function defineAsCustomElement<T extends string>(
       constructor() {
         super(
           attributesMap,
-          init?.methodNames,
           init?.shadowRoot,
           (props, element, setMethodCallback) =>
             patchState(map =>

--- a/packages/react-define-as-custom-element/src/hooks/private/CustomElementContext.ts
+++ b/packages/react-define-as-custom-element/src/hooks/private/CustomElementContext.ts
@@ -1,9 +1,9 @@
-import { createContext, type MutableRefObject } from 'react';
+import { createContext } from 'react';
 
 type CustomElementContextType = {
   customElementState: readonly [HTMLElement | ShadowRoot];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  methodCallbackRef: MutableRefObject<{ [name: string]: ((...args: any[]) => any) | null | undefined }>;
+  setMethodCallback: (name: string, fn: ((...args: any[]) => any) | undefined) => void;
 };
 
 const CustomElementContext = createContext<CustomElementContextType>(

--- a/packages/react-define-as-custom-element/src/hooks/useMethodCallback.ts
+++ b/packages/react-define-as-custom-element/src/hooks/useMethodCallback.ts
@@ -1,6 +1,6 @@
 import useCustomElementContext from './private/useCustomElementContext.ts';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function useMethodCallback<F extends (...args: any[]) => any>(name: string, fn: F | undefined) {
-  useCustomElementContext().methodCallbackRef.current[name] = fn || null;
+export default function useMethodCallback<F extends (...args: any[]) => any>(name: string, fn?: F | undefined) {
+  useCustomElementContext().setMethodCallback(name, fn);
 }

--- a/packages/react-define-as-custom-element/src/private/createReactCustomElement.ts
+++ b/packages/react-define-as-custom-element/src/private/createReactCustomElement.ts
@@ -66,10 +66,12 @@ export default function createReactCustomElement<T extends string>(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     #setMethodCallback(name: string, fn: ((...args: any) => any) | undefined) {
       if (fn) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this as any)[name] = (...args: any[]) => {
           return fn(...args);
         };
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         delete (this as any)[name];
       }
     }

--- a/packages/react-define-as-custom-element/src/types.ts
+++ b/packages/react-define-as-custom-element/src/types.ts
@@ -11,7 +11,6 @@ export type DefineAsCustomElementInit = Readonly<{
         extends: string;
       }
     | undefined;
-  methodNames?: string[] | undefined;
   shadowRoot?: ShadowRootInit | undefined;
 }>;
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Support custom methods by registering via `useMethodCallback()`, by [@compulim](https://github.com/compulim), in PR [#9](https://github.com/compulim/react-define-as-custom-element/pull/9) and [#10](https://github.com/compulim/react-define-as-custom-element/pull/10)

## Specific changes

> Please list each individual specific change in this pull request.

- `useMethodCallback` will register custom methods on-demand
- Eliminate `methodNames`
