### PR TITLE
Add nonce to useMethodCallback to prevent registering more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Attribute changes will be batched via [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/Window/queueMicrotask), by [@compulim](https://github.com/compulim), in PR [#8](https://github.com/compulim/react-define-as-custom-element/pull/8)
-- Support custom methods by registering via `useMethodCallback()`, by [@compulim](https://github.com/compulim), in PR [#9](https://github.com/compulim/react-define-as-custom-element/pull/9) and [#10](https://github.com/compulim/react-define-as-custom-element/pull/10)
+- Support custom methods by registering via `useMethodCallback()`, by [@compulim](https://github.com/compulim), in PR [#9](https://github.com/compulim/react-define-as-custom-element/pull/9), [#10](https://github.com/compulim/react-define-as-custom-element/pull/10), and [#11](https://github.com/compulim/react-define-as-custom-element/pull/11)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ After calling the `useMethodCallback('sum')` hook, a `sum()` function will be ad
 document.getElementsByTagName('my-calculator')[0].sum(1, 2); // Returns 3.
 ```
 
-`useMethodCallback()` hook should only called once for every method. If more than one method is registered with the same name, its behavior will be indeterministic.
+Only one callback function can be registered per method name. The hook will throw if called with the method name that is already registered with another callback function.
 
 ## Behaviors
 
@@ -222,6 +222,10 @@ declare global {
 ### Why are you still using the deprecated `ReactDOM.render` instead of `createRoot()`?
 
 To support React version 16.8 to 18, we are using `ReactDOM.render`, which is available through out the supported versions.
+
+### Can I add property to the custom element?
+
+After defined the custom element, call `customElements.get()` to retrieve the custom element constructor and modify as needed.
 
 ## Roadmap
 

--- a/packages/integration-test/test/webDriver/use-method-callback-dupe/index.html
+++ b/packages/integration-test/test/webDriver/use-method-callback-dupe/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script src="./dist/index.js"></script>
+  </head>
+  <body>
+    <use-method-callback-dupe--my-value></use-method-callback-dupe--my-value>
+  </body>
+</html>

--- a/packages/integration-test/test/webDriver/use-method-callback-dupe/index.tsx
+++ b/packages/integration-test/test/webDriver/use-method-callback-dupe/index.tsx
@@ -1,0 +1,10 @@
+import { defineAsCustomElement, useMethodCallback } from 'react-define-as-custom-element';
+
+const MyValue = () => {
+  useMethodCallback('setValue', () => {});
+  useMethodCallback('setValue', () => {}); // Should throw on calling.
+
+  return false;
+};
+
+defineAsCustomElement(MyValue, 'use-method-callback-dupe--my-value', {});

--- a/packages/integration-test/test/webDriver/use-method-callback-dupe/test.mjs
+++ b/packages/integration-test/test/webDriver/use-method-callback-dupe/test.mjs
@@ -1,0 +1,26 @@
+import { expect } from 'expect';
+import { afterEach, beforeEach, it } from 'mocha';
+import { Browser, Builder } from 'selenium-webdriver';
+import { Level } from 'selenium-webdriver/lib/logging.js';
+
+/** @type {import("selenium-webdriver").WebDriver} */
+let driver;
+
+beforeEach(async () => {
+  driver = await new Builder().forBrowser(Browser.CHROME).usingServer('http://localhost:4444/wd/hub').build();
+});
+
+afterEach(() => driver?.quit());
+
+it('should work', async () => {
+  await driver.get('http://web/use-method-callback-dupe/');
+
+  await expect(driver.manage().logs().get('browser')).resolves.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        level: Level.SEVERE,
+        message: expect.stringContaining(`useMethodCallback('setValue') already registered to another function.`)
+      })
+    ])
+  );
+});

--- a/packages/integration-test/test/webDriver/use-method-callback-dupe/test.mjs
+++ b/packages/integration-test/test/webDriver/use-method-callback-dupe/test.mjs
@@ -19,7 +19,7 @@ it('should work', async () => {
     expect.arrayContaining([
       expect.objectContaining({
         level: Level.SEVERE,
-        message: expect.stringContaining(`useMethodCallback('setValue') already registered to another function.`)
+        message: expect.stringContaining(`useMethodCallback('setValue') is already registered to another function.`)
       })
     ])
   );

--- a/packages/integration-test/test/webDriver/use-method-callback-update/index.html
+++ b/packages/integration-test/test/webDriver/use-method-callback-update/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script src="./dist/index.js"></script>
+  </head>
+  <body>
+    <use-method-callback-update--my-calculator operator="sum"></use-method-callback-update--my-calculator>
+  </body>
+</html>

--- a/packages/integration-test/test/webDriver/use-method-callback-update/index.tsx
+++ b/packages/integration-test/test/webDriver/use-method-callback-update/index.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback, useState } from 'react';
+import { defineAsCustomElement, useMethodCallback } from 'react-define-as-custom-element';
+
+type Props = { operator?: string | undefined };
+
+const MyCalculator = ({ operator }: Props) => {
+  const [variables, setVariables] = useState<[number, number]>([0, 0]);
+
+  useMethodCallback(
+    'compute',
+    useCallback(
+      operator === 'multiply'
+        ? (left: number, right: number): number => {
+            const answer = left * right;
+
+            setVariables([left, right]);
+
+            return answer;
+          }
+        : (left: number, right: number): number => {
+            const answer = left + right;
+
+            setVariables([left, right]);
+
+            return answer;
+          },
+      [operator, setVariables]
+    )
+  );
+
+  const [left, right] = variables;
+
+  return (
+    <span>
+      {left} {operator === 'multiply' ? '*' : '+'} {right} = {operator === 'multiply' ? left * right : left + right}
+    </span>
+  );
+};
+
+defineAsCustomElement(MyCalculator, 'use-method-callback-update--my-calculator', { operator: 'operator' });

--- a/packages/integration-test/test/webDriver/use-method-callback-update/test.mjs
+++ b/packages/integration-test/test/webDriver/use-method-callback-update/test.mjs
@@ -1,0 +1,23 @@
+import { expect } from 'expect';
+import { afterEach, beforeEach, it } from 'mocha';
+import { Browser, Builder } from 'selenium-webdriver';
+
+/** @type {import("selenium-webdriver").WebDriver} */
+let driver;
+
+beforeEach(async () => {
+  driver = await new Builder().forBrowser(Browser.CHROME).usingServer('http://localhost:4444/wd/hub').build();
+});
+
+afterEach(() => driver?.quit());
+
+it('should work', async () => {
+  await driver.get('http://web/use-method-callback-update/');
+
+  // @ts-expect-error
+  await expect(driver.executeScript(() => document.body.firstElementChild?.compute(1, 2))).resolves.toBe(3);
+
+  driver.executeScript(() => document.body.firstElementChild?.setAttribute('operator', 'multiply'));
+
+  await expect(driver.executeScript(() => document.body.textContent?.trim())).resolves.toBe('1 * 2 = 2');
+});

--- a/packages/integration-test/test/webDriver/use-method-callback-update/test.mjs
+++ b/packages/integration-test/test/webDriver/use-method-callback-update/test.mjs
@@ -19,5 +19,8 @@ it('should work', async () => {
 
   driver.executeScript(() => document.body.firstElementChild?.setAttribute('operator', 'multiply'));
 
-  await expect(driver.executeScript(() => document.body.textContent?.trim())).resolves.toBe('1 * 2 = 2');
+  await driver.wait(() => driver.executeScript(() => document.body.textContent?.trim() === '1 * 2 = 2'));
+
+  // @ts-expect-error
+  await expect(driver.executeScript(() => document.body.firstElementChild?.compute(1, 2))).resolves.toBe(2);
 });

--- a/packages/react-define-as-custom-element/src/defineAsCustomElementWithPortal.tsx
+++ b/packages/react-define-as-custom-element/src/defineAsCustomElementWithPortal.tsx
@@ -8,7 +8,11 @@ import { type AttributeAsProps, type AttributesMap, type DefineAsCustomElementIn
 
 type InstanceMapEntry<T extends object> = Readonly<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [HTMLElement | ShadowRoot, Readonly<T>, (name: string, fn: ((...args: any[]) => any) | undefined) => void]
+  [
+    HTMLElement | ShadowRoot,
+    Readonly<T>,
+    (name: string, nonce: number, fn: ((...args: any[]) => any) | undefined) => void
+  ]
 >;
 type InstanceMap<T extends string> = ReadonlyMap<string, InstanceMapEntry<AttributeAsProps<T>>>;
 

--- a/packages/react-define-as-custom-element/src/defineAsCustomElementWithPortal.tsx
+++ b/packages/react-define-as-custom-element/src/defineAsCustomElementWithPortal.tsx
@@ -7,10 +7,10 @@ import signalingState from './signalingState.ts';
 import { type AttributeAsProps, type AttributesMap, type DefineAsCustomElementInit } from './types.ts';
 
 type InstanceMapEntry<T extends object> = Readonly<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [
     HTMLElement | ShadowRoot,
     Readonly<T>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (name: string, nonce: number, fn: ((...args: any[]) => any) | undefined) => void
   ]
 >;

--- a/packages/react-define-as-custom-element/src/hooks/CustomElementProvider.tsx
+++ b/packages/react-define-as-custom-element/src/hooks/CustomElementProvider.tsx
@@ -6,7 +6,7 @@ type Props<T extends Record<string, string | undefined>> = {
   customElement: HTMLElement | ShadowRoot;
   props: T;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setMethodCallback: (name: string, fn: ((...args: any[]) => any) | undefined) => void;
+  setMethodCallback: (name: string, nonce: number, fn: ((...args: any[]) => any) | undefined) => void;
 };
 
 const CustomElementProvider = <T extends Record<string, string | undefined>>({

--- a/packages/react-define-as-custom-element/src/hooks/private/CustomElementContext.ts
+++ b/packages/react-define-as-custom-element/src/hooks/private/CustomElementContext.ts
@@ -3,7 +3,7 @@ import { createContext } from 'react';
 type CustomElementContextType = {
   customElementState: readonly [HTMLElement | ShadowRoot];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setMethodCallback: (name: string, fn: ((...args: any[]) => any) | undefined) => void;
+  setMethodCallback: (name: string, nonce: number, fn: ((...args: any[]) => any) | undefined) => void;
 };
 
 const CustomElementContext = createContext<CustomElementContextType>(

--- a/packages/react-define-as-custom-element/src/hooks/useMethodCallback.ts
+++ b/packages/react-define-as-custom-element/src/hooks/useMethodCallback.ts
@@ -1,6 +1,10 @@
+import mathRandom from 'math-random';
+import { useRef } from 'react';
 import useCustomElementContext from './private/useCustomElementContext.ts';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function useMethodCallback<F extends (...args: any[]) => any>(name: string, fn?: F | undefined) {
-  useCustomElementContext().setMethodCallback(name, fn);
+  const nonceRef = useRef(mathRandom());
+
+  useCustomElementContext().setMethodCallback(name, nonceRef.current, fn);
 }


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Support custom methods by registering via `useMethodCallback()`, by [@compulim](https://github.com/compulim), in PR [#9](https://github.com/compulim/react-define-as-custom-element/pull/9), [#10](https://github.com/compulim/react-define-as-custom-element/pull/10), and [#11](https://github.com/compulim/react-define-as-custom-element/pull/11)

## Specific changes

> Please list each individual specific change in this pull request.

- Added nonce to prevent calling `useMethodCallback` more than once